### PR TITLE
ref(connect): update example with sslnegotiation=direct

### DIFF
--- a/psql-example-connect
+++ b/psql-example-connect
@@ -9,6 +9,6 @@ set -u
 #     Or use `aliasman` (https://webinstall.dev/aliasman) to alias instead of save to file.
 
 # save password to ~/.pgpass with psql-store-credential
-psql "postgres://foobar-xxxxxx@pg-1.example.com:5432/foobar-xxxxxx?sslmode=require"
+psql "postgres://foobar-xxxxxx@pg-1.example.com:5432/foobar-xxxxxx?sslmode=require&sslnegotiation=direct"
 
-#psql "sslmode=require dbname=foobar-xxxxxx" -h pg-1.example.com -p 5432 -U foobar-xxxxxx
+#psql "sslmode=require sslnegotiation=direct dbname=foobar-xxxxxx" -h pg-1.example.com -p 5432 -U foobar-xxxxxx


### PR DESCRIPTION
This causes postgres to use proper TLS, with SNI and ALPN.